### PR TITLE
allow component to be passed into `runComponents`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,8 +74,8 @@ const runningComponents = () => {
   return false
 }
 
-const runComponents = async () => {
-  const serverlessFile = getServerlessFile(process.cwd())
+const runComponents = async (serverlessFileArg) => {
+  const serverlessFile = serverlessFileArg || getServerlessFile(process.cwd())
 
   if (!serverlessFile || !isComponentsFile(serverlessFile)) {
     return


### PR DESCRIPTION
This makes it easy for components to provide their own CLI, see serverless-components/cdn#1 for an example