### PR TITLE
feat: add time elapsed between debug statements

### DIFF
--- a/src/Context.js
+++ b/src/Context.js
@@ -33,6 +33,7 @@ class CLI {
     // Defaults
     this._ = {}
     this._.entity = 'Components'
+    this._.lastDebugTime = null
     this._.useTimer = true
     this._.seconds = 0
     // Status defaults
@@ -294,10 +295,21 @@ class CLI {
       return
     }
 
+    this.lastDebugTime = this.lastDebugTime || new Date()
+
+    const now = new Date()
+    const elapsedMs = now - this.lastDebugTime
+    const elapsedTimeSuffix =
+      elapsedMs > 1000
+        ? chalk.red(`(${Math.floor(elapsedMs / 1000)}s)`)
+        : grey.bold(`(${elapsedMs}ms)`)
+
+    this.lastDebugTime = now
+
     // Clear any existing content
     process.stdout.write(ansiEscapes.eraseDown)
 
-    console.log(`  ${grey.bold(`DEBUG ${figures.line}`)} ${chalk.white(msg)}`) // eslint-disable-line
+    console.log(`  ${grey.bold(`DEBUG ${figures.line}`)} ${chalk.white(msg)} ${elapsedTimeSuffix}`) // eslint-disable-line
 
     // Put cursor to starting position for next view
     process.stdout.write(ansiEscapes.cursorLeft)


### PR DESCRIPTION
@eslam This is something I quickly put together to identify "slow performing" steps in the next component deployments. 

It basically adds the time elapsed between debug statements when using the `--debug` flag. For example:

![image](https://user-images.githubusercontent.com/1122442/66427648-56e70a80-ea0c-11e9-8c92-24534b952f4d.png)

Not sure if this is something you would be interested in adding but thought it could be useful. 


