### PR TITLE
Fix deploy timer

### DIFF
--- a/src/Context.js
+++ b/src/Context.js
@@ -34,6 +34,7 @@ class CLI {
     this._ = {}
     this._.entity = 'Components'
     this._.useTimer = true
+    this._.startTime = Date.now()
     this._.seconds = 0
     // Status defaults
     this._.status = {}
@@ -55,7 +56,7 @@ class CLI {
 
     // Count seconds
     setInterval(() => {
-      this._.seconds++
+      this._.seconds = Math.floor((Date.now() - this._.startTime) / 1000)
     }, 1000)
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -130,6 +130,7 @@ const watch = (component, inputs, method, context) => {
         component = new Component(undefined, context)
         await component.init()
 
+        component.context.instance._.startTime = Date.now()
         component.context.instance._.seconds = 0
         if (method) {
           outputs = await component[method](inputs)
@@ -138,6 +139,7 @@ const watch = (component, inputs, method, context) => {
         }
         // check if another operation is queued
         if (queuedOperation) {
+          component.context.instance._.startTime = Date.now()
           component.context.instance._.seconds = 0
           if (method) {
             outputs = await component[method](inputs)


### PR DESCRIPTION
Measurement of deploy time is not accurate.

`setInterval` callbacks are not issued until event loops ends, so in case of process consuming work involved time shifts are likely.

In other words, there's no guarantee that callback will be invoked every second with milliseconds accuracy.