### PR TITLE
fix: stop silent fail on runComponents when status Engine is inactive

### DIFF
--- a/src/Context.js
+++ b/src/Context.js
@@ -153,8 +153,11 @@ class CLI {
     process.stdout.write(ansiEscapes.cursorShow)
     if (!this.isStatusEngineActive()) {
       console.log() // eslint-disable-line
-      process.exit(0)
-      return
+      if (reason === 'error') {
+        process.exit(1)
+      } else {
+        process.exit(0)
+      }
     }
     return this.statusEngineStop(reason, message)
   }

--- a/src/index.js
+++ b/src/index.js
@@ -233,11 +233,9 @@ const runComponents = async (serverlessFileArg) => {
       }
     }
     context.close('done')
-    process.exit(0)
   } catch (e) {
     context.renderError(e)
     context.close('error', e)
-    process.exit(1)
   }
 }
 


### PR DESCRIPTION
Hello ! 

I ran into an issue of silent fail while running a component. I built a minimum reproductible example [here](https://github.com/fargito/sls-component-silent-fail-example).

The issue I spotted is that the process is always terminated with a zero code if the status engine is inactive, which is not what we want if there has been an error in one of our actions.

Thanks again for maintaining this project ! :)

Closes https://github.com/serverless/cli/issues/9