### PR TITLE
Install binary also at `components-v1` alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Serverless Components CLI",
   "main": "./src/index.js",
   "bin": {
-    "components": "./bin/bin"
+    "components": "./bin/bin",
+    "components-v1": "./bin/bin"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
So eventually Components v2 and v1 can be used together on one system