### PR TITLE
fix: prevent `String.repeat` range error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -226,7 +226,8 @@ const runComponents = async (serverlessFileArg) => {
     if (deferredNotificationsData) {
       const notification = processBackendNotificationRequest(await deferredNotificationsData)
       if (notification) {
-        const borderLength = Math.min(notification.message.length, process.stdout.columns - 2)
+        const ttyLength = Math.max(process.stdout.columns - 2, 0)
+        const borderLength = Math.min(notification.message.length, ttyLength)
         context.log(
           `${'*'.repeat(borderLength)}\n  ${chalk.bold(notification.message)}\n  ${'*'.repeat(
             borderLength


### PR DESCRIPTION
Fixes https://github.com/serverless/cli/issues/25

Small PR to prevent a negative value from being used for `borderLength`, and in turn, throwing a range error.
This only happens when `process.stdout.columns` is equal to `0`, for example, when running inside Docker.

More details in the issue I raised.